### PR TITLE
Rewrite docs/development/schema.md and related components and patterns

### DIFF
--- a/codelist-schema.json
+++ b/codelist-schema.json
@@ -1,0 +1,14 @@
+{
+    "$defs": {
+        "Row": {
+            "properties": {
+                "Deprecated": {
+                    "$ref": "https://codelist-schema.readthedocs.io/1__0__0/codelist-schema.json#/$defs/Row/properties/Deprecated"
+                },
+                "Deprecation note": {
+                    "$ref": "https://codelist-schema.readthedocs.io/1__0__0/codelist-schema.json#/$defs/Row/properties/Deprecation note"
+                }
+            }
+        }
+    }    
+}

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -515,6 +515,12 @@ Allowing conversion between serialization formats (e.g. CSV -> XML; JSON -> XLS)
 
 Data standards often use structured data formats such as JSON or XML to give more flexbility in modelling and to allow validation against schema. Typically, developers prefer to work with structured data formats as they are easier to work with in programs. However, JSON and XML aren't very human-friendly, and people working with data in many domains prefer to use flat representations of data such as CSV and XLSX spreadsheets, both for publishing and manipulating data. Conversion tools allow conversion between the formats, to allow the standard and developers to retain the benfits of a structured data format and users to continue to be able to engage with the data in a way that they're comfortable with.
 
+#### Examples
+
+##### Flatten Tool
+
+We maintain [Flatten Tool](http://flatten-tool.readthedocs.io), a Python library and command-line interface for converting data between structured formats like JSON and XML and tabular formats like CSV and XLSX. It can use a standard's schema to handle data types correctly, to produce human-readable column headings, and to structure tabular data helpfully.
+
 #### Prioritisation Factors
 
 - If the standard uses a structured data format, while data publishers and/or users prefer flat representations.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,7 @@
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinxcontrib.mermaid', 'myst_parser', 'sphinxcontrib.mermaid', 'sphinx_togglebutton', 'sphinx_design']
+extensions = ['sphinxcontrib.mermaid', 'myst_parser', 'sphinxcontrib.mermaid', 'sphinx_togglebutton', 'sphinx_design', 'sphinxcontrib.jsonschema']
 
 # Myst parser configuration
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -359,6 +359,6 @@ linkcheck_anchors = False
 
 
 linkcheck_ignore = [
-    # The ODI is now behind a Clouflare challenge that we can't check.
+    # The ODI is now behind a Cloudflare challenge that we can't check.
     'http://www.theodi.org'
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,7 @@
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinxcontrib.mermaid', 'myst_parser', 'sphinxcontrib.mermaid']
+extensions = ['sphinxcontrib.mermaid', 'myst_parser', 'sphinxcontrib.mermaid', 'sphinx_togglebutton', 'sphinx_design']
 
 # Myst parser configuration
 

--- a/docs/development/schema.md
+++ b/docs/development/schema.md
@@ -129,7 +129,7 @@ Authoring the schema and codelists for a standard involves documenting the stand
 
 JSON Schema specifies a number of keywords to describe and constrain JSON data. For example, the `type` keyword is used to restrict a field to a specific type, like "string" or "number", whilst the `title` keyword is used to provide a human-readable title for a field.
 
-As well as the keywords specified in JSON Schema, the [Open Data Services JSON Schema Extension](https://json-schema-extension.opendataservices.coop) specifies additional keywords for linking fields to [CSV codelists](../patterns/schema.md#csv-codelists),  and providing information about [deprecated fields](../patterns/schema.md#deprecated-fields).
+As well as the keywords specified in JSON Schema, the [Open Data Services JSON Schema Extension](https://json-schema-extension.readthedocs.io/) specifies additional keywords for linking fields to [CSV codelists](../patterns/schema.md#csv-codelists),  and providing information about [deprecated fields](../patterns/schema.md#deprecated-fields).
 
 ```{seealso}
 💡 [Schema patterns](../patterns/schema.md)

--- a/docs/development/schema.md
+++ b/docs/development/schema.md
@@ -1,12 +1,21 @@
-# Schema development
+# Data modelling and schema development
 
-This section outlines a number of the pattens we commonly use to develop the schema for an open data standard.
+This page provides an overview of the steps involved in data modelling and schema development.
 
-```{admonition} Learning / reflection
-class: note
-We currently jump straight from the conceptual framework document, to working up the data model and schema for a standard in a schema language. 
+## Document a data model
 
-This differs [from the approach proposed here](https://github.com/open-contracting-archive/technical-approach#data-model) of maintaining the **data model** as a narrative document, only then given form by a schema as a reference implementation. 
+A data model is an abstract model that organizes elements of data and standardises how they relate to one another and to the properties of real-world entities. A data model focuses on what data represents rather than how it is stored or exchanged.
+
+Before authoring the schema for a standard and committing to specific implementation details, it is recommended to document a data mode to help stakeholders align on definitions and relationships.
+
+The data model for a standard should be based on its [research](research.md) and conceptual framework.
+
+The recommended approach is to document the data model using the [standard development template](../tools.md#standard-development-template-airtable), which ensures that the data model is grounded through explicit links to the requirements, user stories and use cases met by each of its elements.
+
+```{admonition} History
+:class: dropdown
+
+Previously, we moved straight from documenting a conceptual framework to documenting a schema. The reasons for documenting a data model are explored in the [technical scoping](https://github.com/open-contracting-archive/technical-approach?tab=readme-ov-file#data-model) for the Open Contracting Data Standard.
 
 ```
 
@@ -23,12 +32,19 @@ Based on your [research](research.md), you need to decide which publication form
 
 It is best practice for data publishers to provide data in multiple formats, so that as many users as possible can use the data without first having to transform it to their preferred format. Therefore, you should consider how to support publication in multiple formats.
 
-On a technical level, the preferred approach is to use JSON as the format around which a standard's tools are built, and to provide support for other formats through conversion tooling. However, depending on user needs, a standard's documentation site and tooling might present a tabular format, such as CSV, as the primary format.
+On a technical level, the recommended approach is to use JSON as the primary format around which a standard's tools are built, and to provide support for other formats through conversion tooling. Depending on the user needs identified in your research, a standard's documentation site and tooling might present an alternative format, such as CSV, as the primary format.
 
-```{admonition} Examples
+Open Data Services' reusable tools for documenting, converting and validating data are built around JSON. If your research surfaces demand for a different primary format that cannot be supported through conversion to JSON, you should consider the potential costs associated with authoring new tooling.
+
+```{admonition} Example: The Open Contracting Data Standard
 :class: note
 
 The primary publication format of the Open Contracting Data Standard is JSON, but CSV and spreadsheet formats are also supported via conversion tooling. For more information, see [Serialization (Open Contracting Data Standard Documentation)](https://standard.open-contracting.org/latest/en/guidance/build/serialization/#serialization).
+
+```
+
+```{admonition} Example: 360Giving
+:class: note
 
 The 360Giving Data Standard supports both spreadsheet and JSON formats, but most 360Giving data is published in spreadsheet format. Therefore, the documentation for the standard is primarily focussed on the spreadsheet format. For more information, see [Choosing your file format (360Giving Data Standard Documentation)](https://standard.threesixtygiving.org/en/latest/guidance/prepare-data/#choosing-your-file-format).
 
@@ -37,7 +53,7 @@ The 360Giving Data Standard supports both spreadsheet and JSON formats, but most
 ```{seealso}
 
 * 🧩 [Conversion tools](../components/index.md#conversion-tools)
-* 💡 [Spreadsheet first](../patterns/schema.md#spreadsheet-first)
+* 💡 [Spreadsheet first schema design](../patterns/schema.md#spreadsheet-first)
 
 ```
 
@@ -49,15 +65,74 @@ Based on your chosen publication formats, you need to decide on a language in wh
 
 For standards that support JSON as a publication format, the preferred approach is to use [JSON Schema](https://json-schema.org/) to document the canonical schema for the standard, specifically [JSON Schema Draft 2020-12](https://json-schema.org/draft/2020-12). Although less expressive than other schema languages, the constraints of JSON Schema enable a focus on keeping data simple enough for a wide range of users.
 
-```{note} 
+If you choose to support other publication formats alongside JSON, you should consider whether to provide secondary, derived schema for those formats.
+
+```{admonition} Example: Open Referral
+:class: note
+
+The canonical schema for the Open Referral Data Specifications is documented using JSON Schema. However, a secondary schema is provided for the Tabular Data Package format, which is derived from the canonical schema. For more information, see [Serialization and Publication Formats (Open Referral Data Specifications Documentation)](http://docs.openreferral.org/en/latest/hsds/serialization.html).
+
+```
+
+```{admonition} History
 :class: dropdown
 Previously, the recommended approach was to use [JSON Schema Draft 4](https://json-schema.org/draft-04/draft-zyp-json-schema-04). However, Draft 2020-12 contains several useful features not available in Draft 4.
 ```
 
+## Choose a codelist format
+
+A codelist defines a set of permissable values for a field.
+
+The recommended approach is to document codes, titles and descriptions in a CSV file, according to the [Open Data Services Codelist Schema](https://codelist-schema.opendataservices.coop/).
+
+```{seealso}
+* 💡 [CSV codelists](../patterns/schema.md#csv-codelists)
+```
+
+## Choose your packaging formats
+
+A packaging format is structued way of bundling together data and, sometimes, metadata. You can think of a packaging format as a container for multiple records, texts or documents.
+
+Packaging formats aid interoperability and reuse by providing tool developers and analysts with predicatable and consistent approaches to grouping records, streaming and pagination.
+
+Based on your chosen publication formats and the requirements identified in your research, you need to decide on a packaging format or formats for each publication format.
+
+The recommended approach is to consider providing:
+
+* A small file and API response format for files that are small enough to fit into memory or are published via API.
+* A bulk download format for files that are too large to fit into memory.
+
+```{admonition} Example: The Open Fibre Data Standard
+:class: note
+
+The Open Fibre Data Standard supports publication in JSON, GeoJSON and CSV formats. For the JSON and GeoJSON formats, it provides containers for publishing one or more networks and options to support pagination and streaming:
+
+Format | Small files and API responses | Streaming
+--- | --- | ---
+JSON | A JSON object with an embedded array of `Network` objects, with an optional `.links` object for pagination | A [JSON Lines](https://jsonlines.org/) file in which each line is an `Network` object.
+GeoJSON | GeoJSON [feature collections](https://datatracker.ietf.org/doc/html/rfc7946#section-3.3), with an optional `.links` object for pagination | [Newline-delimited GeoJSON](https://stevage.github.io/ndgeojson/) files
+
+```
+
+```{seealso}
+* 💡 [Packaging](../patterns/schema.md#packaging)
+* 💬 [Packaging multiple networks · Issue #51 · Open-Telecoms-Data/open-fibre-data-standard](https://github.com/Open-Telecoms-Data/open-fibre-data-standard/issues/51)
+* 💬 [Deprecate remaining package metadata and add bulk data format · Issue #1084 · open-contracting/standard](https://github.com/open-contracting/standard/issues/1084)
+* 💬 [Add a metadata package schema · Issue #200 · GFDRR/rdl-standard](https://github.com/GFDRR/rdl-standard/issues/200)
+```
+
+## Author your schema and codelists
+
+Developing a good schema is an art as much as a science. It requires sensitivity to the needs of both data producers and data users, and an understanding of the incentive structures that will drive adoption of a standard.
+
+```{seealso}
+[Schema patterns](../patterns/schema.md)
+The following section provides links to a non-exhaustive set of design patterns that can be drawn upon when developing a schema. 
+```
+
 JSON Schema specifies a number of keywords to describe and constrain JSON data. For example, the `type` keyword is used to restrict a field to a specific type, like "string" or "number", whilst the `title` keyword is used to provide a human-readable title for a field.
 
-As well as the keywords specified in JSON Schema, the [Open Data Services JSON Schema Extension]() specifies additional keywords for linking fields to [CSV codelists](../patterns/schema.md#csv-codelists),  and providing information about [deprecated fields](../patterns/schema.md#deprecated-fields).
-
+As well as the keywords specified in JSON Schema, the [Open Data Services JSON Schema Extension](https://json-schema-extension.opendataservices.coop) specifies additional keywords for linking fields to [CSV codelists](../patterns/schema.md#csv-codelists),  and providing information about [deprecated fields](../patterns/schema.md#deprecated-fields).
 
 ### Merge strategies
 
@@ -69,41 +144,8 @@ The Open Contracting Data Standard describes an approach to merge together relea
 
 Behaviour for these is [described in the OCDS documentation](http://standard.open-contracting.org/1.1/en/schema/merging/#merging-rules).
 
-If you choose to support other publication formats alongside JSON, you should consider whether to provide secondary, derived schema for those formats.
-
-```{admonition} Examples
-:class: note
-
-The canonical schema for the Open Referral Data Specifications are documented as a JSON Schema. However, the standard also supports Tabular Data Package as a publication format and provides a secondary Tabular Data Package schema, known as a package descriptor, which is derived from the canonical JSON Schema. For more information, see [Serialization and Publication Formats (Open Referral Data Specifications Documentation)](http://docs.openreferral.org/en/latest/hsds/serialization.html).
-
-```
-
 ```{seealso}
 
 * 🧩 [Schema](../components/index.md#schema)
 
-```
-
-## Choose a codelist format
-
-A codelist defines a set of permissable values for a field.
-
-Alongside JSON Schema, our preferred approach is to document codes, titles and descriptions in a CSV file.
-We generally use simple CSV files to represent codelists.
-
-We have a number of extensions to JSON Schema 0.4 we use (documented below).
-
-## Choose your packaging formats
-
-
-
-
-
-## Design patterns
-
-Developing a good schema is an art as much as a science. It requires sensitivity to the needs of both data producers and data users, and an understanding of the incentive structures that will drive adoption of a standard.
-
-```{seealso}
-[Schema patterns](../patterns/schema.md)
-The following section provides links to a non-exhaustive set of design patterns that can be drawn upon when developing a schema. 
 ```

--- a/docs/development/schema.md
+++ b/docs/development/schema.md
@@ -6,13 +6,13 @@ This page provides an overview of the steps involved in data modelling and schem
 
 A data model is an abstract model that organizes elements of data and standardises how they relate to one another and to the properties of real-world entities. A data model focuses on what data represents rather than how it is stored or exchanged.
 
-Before authoring the schema for a standard and committing to specific implementation details, it is recommended to document a data mode to help stakeholders align on definitions and relationships.
+Before authoring the schema for a standard and committing to specific implementation details, it is recommended to document a data model to help stakeholders align on definitions and relationships.
 
-The data model for a standard should be based on its [research](research.md) and conceptual framework. Documenting the data model for a standard involves identifying and defining the entities (classes), attributes (properties), relationships and permissable values (codelists) needed to satisfy the requirements, user stories and use cases for the standard.
+The data model for a standard should be based on [research](research.md) into the related policy-area and a thorough understanding of the concepts which underpin it (a conceptual model). Documenting the data model for a standard involves identifying and defining the entities (classes), attributes (properties), relationships and permissable values (codelists) needed to satisfy the requirements, user stories and use cases for the standard.
 
-Developing a good schema is an art as much as a science. It requires sensitivity to the needs of both data producers and data users, and an understanding of the incentive structures that will drive adoption of a standard.
+Developing a good data model is an art as much as a science. It requires sensitivity to the needs of both data producers and data users, and an understanding of the incentive structures that will drive adoption of a standard.
 
-The recommended approach is to document the data model using the [standard development template](../tools.md#standard-development-template-airtable), which ensures that the data model is grounded through explicit links to the requirements, user stories and use cases met by each of its elements.
+The recommended approach is to document the data model using the [standard development template](../tools.md#standard-development-template-airtable), which ensures that the data model is grounded through explicit links to the requirements, user stories and use cases.
 
 ```{admonition} History
 :class: dropdown

--- a/docs/development/schema.md
+++ b/docs/development/schema.md
@@ -3,57 +3,61 @@
 This section outlines a number of the pattens we commonly use to develop the schema for an open data standard.
 
 ```{admonition} Learning / reflection
----
 class: note
----
 We currently jump straight from the conceptual framework document, to working up the data model and schema for a standard in a schema language. 
 
 This differs [from the approach proposed here](https://github.com/open-contracting-archive/technical-approach#data-model) of maintaining the **data model** as a narrative document, only then given form by a schema as a reference implementation. 
 
 ```
 
-## Schema language
+## Choose your publication formats
 
-Our preferred schema language is [JSON Schema v0.4](https://tools.ietf.org/html/draft-zyp-json-schema-04).
+A publication format is a format in which data can be published by implementers of a standard. Common publication formats include:
 
-This allows us to provide field structures and definitions. Although less expressive than other schema languages, the constraints of JSON Schema enable us to focus on keeping data simple enough for a wide range of users.
+* [JSON]()
+* [GeoJSON]()
+* [CSV]() and other tabular formats, such as XLSX and ODS.
+* [XML]()
 
-We generally use simple CSV files to represent codelists.
+Based on your [research](research.md), you need to decide which publication formats to support.
 
-We have a number of extensions to JSON Schema 0.4 we use (documented below).
+It is best practice for data publishers to provide data in multiple formats, so that as many users as possible can use the data without first having to transform it to their preferred format. Therefore, you should consider how to support publication in multiple formats.
 
-## Serializations
+On a technical level, the preferred approach is to use JSON as the format around which a standard's tools are built, and to provide support for other formats through conversion tooling. However, depending on user needs, a standard's documentation site and tooling might present a tabular format, such as CSV, as the primary format.
 
-We design with a range of serializations in mind, and, where possible, to enable round-tripping of data between different serializations.
+```{admonition} Examples
+:class: note
 
-In particular, through [flatten-tool](http://flatten-tool.readthedocs.io) we design with support for:
+The primary publication format of the Open Contracting Data Standard is JSON, but CSV and spreadsheet formats are also supported via conversion tooling. For more information, see [Serialization (Open Contracting Data Standard Documentation)](https://standard.open-contracting.org/latest/en/guidance/build/serialization/#serialization).
 
-- Structured JSON serialization;
-- Excel serialization;
-- CSV serialization.
+The 360Giving Data Standard supports both spreadsheet and JSON formats, but most 360Giving data is published in spreadsheet format. Therefore, the documentation for the standard is primarily focussed on the spreadsheet format. For more information, see [Choosing your file format (360Giving Data Standard Documentation)](https://standard.threesixtygiving.org/en/latest/guidance/prepare-data/#choosing-your-file-format).
 
-[Flatten-tool](http://flatten-tool.readthedocs.io/en/latest/unflatten/#human-friendly-headings-using-a-json-schema-with-titles) can use the titles in a schema to provide 'friendly' column headings, and with use of a [metatab](http://flatten-tool.readthedocs.io/en/latest/unflatten/#metadata-tab) also supports packaging meta-data and options to control how spreadsheets are parsed.
+```
 
-## Extended JSON schema
+```{seealso}
 
-We use a number of custom properties in our JSON Schema implementation. A [patch against JSON Schema 0.4 to include these is found here](https://github.com/open-contracting/standard/blob/6e538252dd08344222b5cd16b864ed0a2a866197/standard/schema/metaschema/meta-schema-patch.json).
+* 🧩 [Conversion tools](../components/index.md#conversion-tools)
+* 💡 [Spreadsheet first](../patterns/schema.md#spreadsheet-first)
 
-### Codelist properties
+```
 
-- `codelist` - the filename of a .csv file that contains at least a `Code` column. Used by the CoVE validator to check for acceptable values.
-- `openCodelist` - a boolean value to indicate whether values can **only** come from the codelist, or whether additional values not on the codelist are permitted. When `openCodelist` = 'true' then encountering a value not on the codelist should generate a warning. When `openCodelist` = 'false' then encountering a value not on the codelist should generate an error.
+## Choose a schema language
 
-### Deprecation properties
+A schema defines the meaning, structure and format of data.
 
-> "Deprecation is the discouragement of use of some terminology, feature, design, or practice; typically because it has been superseded or is no longer considered efficient or safe – but without completely removing it or prohibiting its use."
+Based on your chosen publication formats, you need to decide on a language in which to document the schema for a standard, 
 
-See: [Deprecation (Wikipedia)](https://en.wikipedia.org/wiki/Deprecation)
+For standards that support JSON as a publication format, the preferred approach is to use [JSON Schema](https://json-schema.org/) to document the canonical schema for the standard, specifically [JSON Schema Draft 2020-12](https://json-schema.org/draft/2020-12). Although less expressive than other schema languages, the constraints of JSON Schema enable a focus on keeping data simple enough for a wide range of users.
 
-- `deprecated` - and object to indicate that the field is deprecated, consisting of fields for:
-  - `description` - a message that explains the deprecation, and that should be presented by validators to any publisher using this field.
-  - `deprecatedVersion` - a string indicating the version in which the field was first deprecated.
+```{note} 
+:class: dropdown
+Previously, the recommended approach was to use [JSON Schema Draft 4](https://json-schema.org/draft-04/draft-zyp-json-schema-04). However, Draft 2020-12 contains several useful features not available in Draft 4.
+```
 
-We also use the column title `Deprecated` with a version number as the cell value in codelist CSV files when a code has been deprecated.
+JSON Schema specifies a number of keywords to describe and constrain JSON data. For example, the `type` keyword is used to restrict a field to a specific type, like "string" or "number", whilst the `title` keyword is used to provide a human-readable title for a field.
+
+As well as the keywords specified in JSON Schema, the [Open Data Services JSON Schema Extension]() specifies additional keywords for linking fields to [CSV codelists](../patterns/schema.md#csv-codelists),  and providing information about [deprecated fields](../patterns/schema.md#deprecated-fields).
+
 
 ### Merge strategies
 
@@ -64,6 +68,36 @@ The Open Contracting Data Standard describes an approach to merge together relea
 - `versionId`
 
 Behaviour for these is [described in the OCDS documentation](http://standard.open-contracting.org/1.1/en/schema/merging/#merging-rules).
+
+If you choose to support other publication formats alongside JSON, you should consider whether to provide secondary, derived schema for those formats.
+
+```{admonition} Examples
+:class: note
+
+The canonical schema for the Open Referral Data Specifications are documented as a JSON Schema. However, the standard also supports Tabular Data Package as a publication format and provides a secondary Tabular Data Package schema, known as a package descriptor, which is derived from the canonical JSON Schema. For more information, see [Serialization and Publication Formats (Open Referral Data Specifications Documentation)](http://docs.openreferral.org/en/latest/hsds/serialization.html).
+
+```
+
+```{seealso}
+
+* 🧩 [Schema](../components/index.md#schema)
+
+```
+
+## Choose a codelist format
+
+A codelist defines a set of permissable values for a field.
+
+Alongside JSON Schema, our preferred approach is to document codes, titles and descriptions in a CSV file.
+We generally use simple CSV files to represent codelists.
+
+We have a number of extensions to JSON Schema 0.4 we use (documented below).
+
+## Choose your packaging formats
+
+
+
+
 
 ## Design patterns
 

--- a/docs/development/schema.md
+++ b/docs/development/schema.md
@@ -8,7 +8,7 @@ A data model is an abstract model that organizes elements of data and standardis
 
 Before authoring the schema for a standard and committing to specific implementation details, it is recommended to document a data model to help stakeholders align on definitions and relationships.
 
-The data model for a standard should be based on [research](research.md) into the related policy-area and a thorough understanding of the concepts which underpin it (a conceptual model). Documenting the data model for a standard involves identifying and defining the entities (classes), attributes (properties), relationships and permissable values (codelists) needed to satisfy the requirements, user stories and use cases for the standard.
+The data model for a standard should be based on [research](research.md) into the related policy area and a thorough understanding of the concepts which underpin it (a conceptual model). Documenting the data model for a standard involves identifying and defining the entities (classes), attributes (properties), relationships and permissable values (codelists) needed to satisfy the requirements, user stories and use cases for the standard.
 
 Developing a good data model is an art as much as a science. It requires sensitivity to the needs of both data producers and data users, and an understanding of the incentive structures that will drive adoption of a standard.
 

--- a/docs/development/schema.md
+++ b/docs/development/schema.md
@@ -8,7 +8,7 @@ A data model is an abstract model that organizes elements of data and standardis
 
 Before authoring the schema for a standard and committing to specific implementation details, it is recommended to document a data mode to help stakeholders align on definitions and relationships.
 
-The data model for a standard should be based on its [research](research.md) and conceptual framework. Documenting the data model for a standard involves identifying and defining the entities (classes), attributes (properties), relationships and permissable values (codelists) needed to the requirements, user stories and use cases the standard.
+The data model for a standard should be based on its [research](research.md) and conceptual framework. Documenting the data model for a standard involves identifying and defining the entities (classes), attributes (properties), relationships and permissable values (codelists) needed to satisfy the requirements, user stories and use cases for the standard.
 
 Developing a good schema is an art as much as a science. It requires sensitivity to the needs of both data producers and data users, and an understanding of the incentive structures that will drive adoption of a standard.
 

--- a/docs/development/schema.md
+++ b/docs/development/schema.md
@@ -8,7 +8,9 @@ A data model is an abstract model that organizes elements of data and standardis
 
 Before authoring the schema for a standard and committing to specific implementation details, it is recommended to document a data mode to help stakeholders align on definitions and relationships.
 
-The data model for a standard should be based on its [research](research.md) and conceptual framework.
+The data model for a standard should be based on its [research](research.md) and conceptual framework. Documenting the data model for a standard involves identifying and defining the entities (classes), attributes (properties), relationships and permissable values (codelists) needed to the requirements, user stories and use cases the standard.
+
+Developing a good schema is an art as much as a science. It requires sensitivity to the needs of both data producers and data users, and an understanding of the incentive structures that will drive adoption of a standard.
 
 The recommended approach is to document the data model using the [standard development template](../tools.md#standard-development-template-airtable), which ensures that the data model is grounded through explicit links to the requirements, user stories and use cases met by each of its elements.
 
@@ -23,14 +25,14 @@ Previously, we moved straight from documenting a conceptual framework to documen
 
 A publication format is a format in which data can be published by implementers of a standard. Common publication formats include:
 
-* [JSON]()
-* [GeoJSON]()
-* [CSV]() and other tabular formats, such as XLSX and ODS.
-* [XML]()
+* [JSON](https://www.json.org/json-en.html)
+* [GeoJSON](https://datatracker.ietf.org/doc/html/rfc7946)
+* [CSV](https://en.wikipedia.org/wiki/Comma-separated_values) and other tabular formats, such as XLSX and ODS.
+* [XML](https://www.w3.org/TR/xml/)
 
 Based on your [research](research.md), you need to decide which publication formats to support.
 
-It is best practice for data publishers to provide data in multiple formats, so that as many users as possible can use the data without first having to transform it to their preferred format. Therefore, you should consider how to support publication in multiple formats.
+It is [best practice](https://www.w3.org/TR/dwbp/#MultipleFormats) for data publishers to provide data in multiple formats, so that as many users as possible can use the data without first having to transform it to their preferred format. Therefore, you should consider how to support publication in multiple formats.
 
 On a technical level, the recommended approach is to use JSON as the primary format around which a standard's tools are built, and to provide support for other formats through conversion tooling. Depending on the user needs identified in your research, a standard's documentation site and tooling might present an alternative format, such as CSV, as the primary format.
 
@@ -83,7 +85,7 @@ Previously, the recommended approach was to use [JSON Schema Draft 4](https://js
 
 A codelist defines a set of permissable values for a field.
 
-The recommended approach is to document codes, titles and descriptions in a CSV file, according to the [Open Data Services Codelist Schema](https://codelist-schema.opendataservices.coop/).
+The recommended approach is to document codes, titles and descriptions in a CSV file, according to the [Open Data Services Codelist Schema](https://codelist-schema.readthedocs.io/).
 
 ```{seealso}
 * 💡 [CSV codelists](../patterns/schema.md#csv-codelists)
@@ -93,7 +95,7 @@ The recommended approach is to document codes, titles and descriptions in a CSV 
 
 A packaging format is structued way of bundling together data and, sometimes, metadata. You can think of a packaging format as a container for multiple records, texts or documents.
 
-Packaging formats aid interoperability and reuse by providing tool developers and analysts with predicatable and consistent approaches to grouping records, streaming and pagination.
+Packaging formats aid interoperability and reuse by providing tool developers and analysts with predicatable and consistent approaches to grouping, streaming and pagination.
 
 Based on your chosen publication formats and the requirements identified in your research, you need to decide on a packaging format or formats for each publication format.
 
@@ -123,29 +125,12 @@ GeoJSON | GeoJSON [feature collections](https://datatracker.ietf.org/doc/html/rf
 
 ## Author your schema and codelists
 
-Developing a good schema is an art as much as a science. It requires sensitivity to the needs of both data producers and data users, and an understanding of the incentive structures that will drive adoption of a standard.
-
-```{seealso}
-[Schema patterns](../patterns/schema.md)
-The following section provides links to a non-exhaustive set of design patterns that can be drawn upon when developing a schema. 
-```
+Authoring the schema and codelists for a standard involves documenting the standard's data model in your chosen schema language and codelist formats.
 
 JSON Schema specifies a number of keywords to describe and constrain JSON data. For example, the `type` keyword is used to restrict a field to a specific type, like "string" or "number", whilst the `title` keyword is used to provide a human-readable title for a field.
 
 As well as the keywords specified in JSON Schema, the [Open Data Services JSON Schema Extension](https://json-schema-extension.opendataservices.coop) specifies additional keywords for linking fields to [CSV codelists](../patterns/schema.md#csv-codelists),  and providing information about [deprecated fields](../patterns/schema.md#deprecated-fields).
 
-### Merge strategies
-
-The Open Contracting Data Standard describes an approach to merge together releases of data from different point in time. We add a number of properties to indicate how merging should be approached.
-
-- `omitWhemMerged`
-- `wholeListMerge`
-- `versionId`
-
-Behaviour for these is [described in the OCDS documentation](http://standard.open-contracting.org/1.1/en/schema/merging/#merging-rules).
-
 ```{seealso}
-
-* 🧩 [Schema](../components/index.md#schema)
-
+💡 [Schema patterns](../patterns/schema.md)
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,6 +41,7 @@ adoption/index
 learning/index
 components/index
 patterns/index
+tools
 about/index
 meta/index
 

--- a/docs/patterns/schema.md
+++ b/docs/patterns/schema.md
@@ -218,7 +218,7 @@ Use the following columns from the [Open Data Services Codelist Schema]():
 
 The 'bestValueToGovernment' code is deprecated in favour of 'ratedCriteria':
 
-```csv
+```
 Code,Title,Description,Deprecated,Deprecated version,Deprecated description
 bestValueToGovernment,Best value to government,True,1.2,This code has been deprecated. 'ratedCriteria' is a likely alternatives for most procedures formerly mapped to this code.
 ```
@@ -345,15 +345,15 @@ The [OCDS Extension Template](https://github.com/open-contracting/standard_exten
 ---
 
 
-## CSV Codelists
+## CSV codelists
 
 ### Problem
 
-The JSON Schema [`enum` keyword](https://json-schema.org/understanding-json-schema/reference/enum) restricts a field to a fixed set of values. When applied to field with of the [`string` type](https://json-schema.org/understanding-json-schema/reference/string), the restricted set of values is known as a closed codelist.
+The JSON Schema [`enum` keyword](https://json-schema.org/understanding-json-schema/reference/enum) restricts a field to a fixed set of values. When applied to field of the [`string` type](https://json-schema.org/understanding-json-schema/reference/string), the restricted set of values is known as a closed codelist.
 
 Sometimes, it is desirable to specify a list of optional values for a field, whilst allowing values outside the list. Such lists of optional values are known as open codelists. JSON Schema does not provide a means to define an open codelist for a field.
 
-Data publishers and users need to understand the meaning of the values in a codelist. However, JSON Schema does not provide a means to annotate the enumerated values with metadata like human-readable titles and descriptions.
+Data publishers and users need to understand the meaning of the values in a codelist. However, JSON Schema does not provide a means to annotate enumerated values with metadata like human-readable titles and descriptions.
 
 ### Solution
 
@@ -363,34 +363,44 @@ For each open or closed codelist in the schema, document its codes with at least
 
 For each field that references a codelist:
 
-1. Document the CSV files according to the [Open Data Services CSV Codelist Schema]().
-1. Use the `codelist` keyword from the [Open Data Services JSON Schema Extension]() to specify the CSV file associated with the field.
+1. Document the codelist as a CSV file according to the [Open Data Services Codelist Schema](https://codelist-schema.opendataservices.coop).
+1. Use the `codelist` keyword from the [Open Data Services JSON Schema Extension](https://json-schema-extension.opendataservices.coop) to specify the CSV file associated with the field.
 
 ### Example
 
-In the Open Contracting Data Standard, [`tender.status`](https://standard.open-contracting.org/1.1/en/schema/reference/#release-schema.json,/definitions/Tender,status) references [`tenderStatus.csv`](https://github.com/open-contracting/standard/blob/1.1/schema/codelists/tenderStatus.csv).
+The `status` field refers to a closed codelist. Its codes are documented in `status.csv`.
+
+#### Schema
 
 ```json
 {
-    "status": {
-        "title": "Tender status",
-        "description": "The current status of the tender, from the closed [tenderStatus](https://standard.open-contracting.org/{{version}}/{{lang}}/schema/codelists/#tender-status) codelist.",
-        "type": [
-        "string",
-        "null"
-        ],
-        "codelist": "tenderStatus.csv",
-        "openCodelist": false,
-        "enum": [
-        "planning",
-        "planned",
-        "active",
-        "cancelled",
-        "unsuccessful",
-        "complete",
-        "withdrawn",
-        null
-        ]
+    "properties": {
+        "status": {
+            "title": "Status",
+            "type": [
+                "string"
+            ],
+            "enum": [
+                "planned",
+                "active",
+                "complete",
+            ],
+            "codelist": "status.csv",
+        }
     }
 }
 ```
+
+#### CSV codelist
+
+```csv
+Code,Title,Description
+planned,Planned,The process is planned
+active,Active,The process is active
+complete,Complete,The process is complete
+```
+
+
+
+
+

--- a/docs/patterns/schema.md
+++ b/docs/patterns/schema.md
@@ -168,9 +168,11 @@ Use the [`deprecated`](https://json-schema.org/understanding-json-schema/referen
 :class: dropdown
 [JSON Schema Draft 4](https://json-schema.org/draft-04/draft-zyp-json-schema-04) lacked a means to indicate a deprecated field. The `deprecated` keyword was added in Draft 2020-12.
 ```
-Use the following keywords from the [Open Data Services JSON Schema Extension]():
+Use the `deprecatedDetails` keyword from the [Open Data Services JSON Schema Extension](https://json-schema-extension.readthedocs.io) to provide information about the deprecation of a field:
 
-```{jsonschema} schema/meta-schema-patch.json
+```{jsonschema} ../../metaschema.json
+:allowexternalrefs:
+:nocrossref:
 :include: deprecatedDetails
 ```
 
@@ -184,7 +186,7 @@ The `.countryName` field is deprecated in favour of `.country`:
     "title": "Country name",
     "type": "string",
     "deprecated": true,
-    "deprecationDetails": {
+    "deprecatedDetails": {
       "deprecatedVersion": "1.1",
       "description": "This field is deprecated in favor of `country`, to promote standardized country codes instead of non-standardized country names."
     }
@@ -208,10 +210,13 @@ Annotate codes to indicate deprecation and replacements.
 
 ### Method
 
-Use the following columns from the [Open Data Services Codelist Schema]():
+Use the following columns from the [Open Data Services Codelist Schema](https://codelist-schema.readthedocs.io):
 
-```{jsonschema} schema/codelist-schema.json
-:include: "Deprecated", "Deprecation version", "Deprecation description"
+```{jsonschema} ../../codelist-schema.json
+:allowexternalrefs:
+:nocrossref:
+:pointer: /$defs/Row
+:include: Deprecated,Deprecation note
 ```
 
 ### Example
@@ -305,7 +310,13 @@ Merging together data in sequential order (oldest first) can create an object th
 
 ### Method
 
-To be documented.
+The Open Contracting Data Standard describes an approach to merge together releases of data from different point in time. We add a number of properties to indicate how merging should be approached.
+
+- `omitWhemMerged`
+- `wholeListMerge`
+- `versionId`
+
+Behaviour for these is [described in the OCDS documentation](http://standard.open-contracting.org/1.1/en/schema/merging/#merging-rules).
 
 ### Example
 

--- a/docs/patterns/schema.md
+++ b/docs/patterns/schema.md
@@ -374,8 +374,8 @@ For each open or closed codelist in the schema, document its codes with at least
 
 For each field that references a codelist:
 
-1. Document the codelist as a CSV file according to the [Open Data Services Codelist Schema](https://codelist-schema.opendataservices.coop).
-1. Use the `codelist` keyword from the [Open Data Services JSON Schema Extension](https://json-schema-extension.opendataservices.coop) to specify the CSV file associated with the field.
+1. Document the codelist as a CSV file according to the [Open Data Services Codelist Schema](https://codelist-schema.readthedocs.io/).
+1. Use the `codelist` keyword from the [Open Data Services JSON Schema Extension](https://json-schema-extension.readthedocs.io/) to specify the CSV file associated with the field.
 
 ### Example
 

--- a/docs/patterns/schema.md
+++ b/docs/patterns/schema.md
@@ -224,8 +224,8 @@ Use the following columns from the [Open Data Services Codelist Schema](https://
 The 'bestValueToGovernment' code is deprecated in favour of 'ratedCriteria':
 
 ```
-Code,Title,Description,Deprecated,Deprecated version,Deprecated description
-bestValueToGovernment,Best value to government,True,1.2,This code has been deprecated. 'ratedCriteria' is a likely alternatives for most procedures formerly mapped to this code.
+Code,Title,Description,Deprecated,Deprecation note
+bestValueToGovernment,Best value to government,1.2,This code has been deprecated. 'ratedCriteria' is a likely alternatives for most procedures formerly mapped to this code.
 ```
 
 ---

--- a/docs/patterns/schema.md
+++ b/docs/patterns/schema.md
@@ -148,23 +148,80 @@ Add example from Social Investment Data Lab Standard
 
 ---
 
-## Deprecation
+## Deprecated fields
 
 ### Problem
 
-Fields may need to be removed from a standard. When these are removed, users may not know how to update their data.
+Fields sometimes need to be removed from a schema.
+
+Data publishers and data users need to know when a field is going to be removed and what field replaces it.
 
 ### Solution
 
-Mark fields as deprecated for at least one version prior to their removal. Provide a deprecation message that explains to users how to change their data.
+At least one version before removing a field, annotate it to indicate deprecation and replacements.
 
 ### Method
 
-We use [extended JSON schema fields for deprecation](#deprecation).
+Use the [`deprecated`](https://json-schema.org/understanding-json-schema/reference/annotations) keyword from JSON Schema to indicate deprecation.
+
+```{note} 
+:class: dropdown
+[JSON Schema Draft 4](https://json-schema.org/draft-04/draft-zyp-json-schema-04) lacked a means to indicate a deprecated field. The `deprecated` keyword was added in Draft 2020-12.
+```
+Use the following keywords from the [Open Data Services JSON Schema Extension]():
+
+```{jsonschema} schema/meta-schema-patch.json
+:include: deprecatedDetails
+```
 
 ### Example
 
-OCDS Version 1.1 deprecated a number of fields. The validator will report when deprecated fields are encountered in data.
+The `.countryName` field is deprecated in favour of `.country`:
+
+```json
+{
+  "countryName": {
+    "title": "Country name",
+    "type": "string",
+    "deprecated": true,
+    "deprecationDetails": {
+      "deprecatedVersion": "1.1",
+      "description": "This field is deprecated in favor of `country`, to promote standardized country codes instead of non-standardized country names."
+    }
+  }
+}
+```
+
+---
+
+## Deprecated codes
+
+### Problem
+
+Codes sometimes need to be removed from a codelist.
+
+Data publishers and data users need to know when a code is going to be removed and what code replaces it.
+
+### Solution
+
+Annotate codes to indicate deprecation and replacements.
+
+### Method
+
+Use the following columns from the [Open Data Services Codelist Schema]():
+
+```{jsonschema} schema/codelist-schema.json
+:include: "Deprecated", "Deprecation version", "Deprecation description"
+```
+
+### Example
+
+The 'bestValueToGovernment' code is deprecated in favour of 'ratedCriteria':
+
+```csv
+Code,Title,Description,Deprecated,Deprecated version,Deprecated description
+bestValueToGovernment,Best value to government,True,1.2,This code has been deprecated. 'ratedCriteria' is a likely alternatives for most procedures formerly mapped to this code.
+```
 
 ---
 
@@ -284,3 +341,56 @@ When extensions are declared in packaging meta-data, validators and other tools 
 ### Example
 
 The [OCDS Extension Template](https://github.com/open-contracting/standard_extension_template) and [extensions registry](http://standard.open-contracting.org/latest/en/extensions/) document a technical approach to extensions.
+
+---
+
+
+## CSV Codelists
+
+### Problem
+
+The JSON Schema [`enum` keyword](https://json-schema.org/understanding-json-schema/reference/enum) restricts a field to a fixed set of values. When applied to field with of the [`string` type](https://json-schema.org/understanding-json-schema/reference/string), the restricted set of values is known as a closed codelist.
+
+Sometimes, it is desirable to specify a list of optional values for a field, whilst allowing values outside the list. Such lists of optional values are known as open codelists. JSON Schema does not provide a means to define an open codelist for a field.
+
+Data publishers and users need to understand the meaning of the values in a codelist. However, JSON Schema does not provide a means to annotate the enumerated values with metadata like human-readable titles and descriptions.
+
+### Solution
+
+For each open or closed codelist in the schema, document its codes with at least a title and description, in a CSV file.
+
+### Method
+
+For each field that references a codelist:
+
+1. Document the CSV files according to the [Open Data Services CSV Codelist Schema]().
+1. Use the `codelist` keyword from the [Open Data Services JSON Schema Extension]() to specify the CSV file associated with the field.
+
+### Example
+
+In the Open Contracting Data Standard, [`tender.status`](https://standard.open-contracting.org/1.1/en/schema/reference/#release-schema.json,/definitions/Tender,status) references [`tenderStatus.csv`](https://github.com/open-contracting/standard/blob/1.1/schema/codelists/tenderStatus.csv).
+
+```json
+{
+    "status": {
+        "title": "Tender status",
+        "description": "The current status of the tender, from the closed [tenderStatus](https://standard.open-contracting.org/{{version}}/{{lang}}/schema/codelists/#tender-status) codelist.",
+        "type": [
+        "string",
+        "null"
+        ],
+        "codelist": "tenderStatus.csv",
+        "openCodelist": false,
+        "enum": [
+        "planning",
+        "planned",
+        "active",
+        "cancelled",
+        "unsuccessful",
+        "complete",
+        "withdrawn",
+        null
+        ]
+    }
+}
+```

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -6,7 +6,7 @@ This page lists tools for standard development.
 
 ### Standard Development Template (Airtable)
 
-The [Standard Development Template](https://airtable.com/appPKPGl0TPBAEjyW/) is a tool for managing and documenting the research and development of a data standard. It is structured according to the standard development methodology documented in this handbook.
+The [Standard Development Template](https://airtable.com/appPKPGl0TPBAEjyW/shrTREzZjthYCdj1g) is a tool for managing and documenting the research and development of a data standard. It is structured according to the standard development methodology documented in this handbook.
 
 The template is designed to promote rigorous documentation of use cases, user stories, and requirements, while ensuring that the data model is grounded through explicit links to the requirements met by each of its elements.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -8,6 +8,6 @@ This page lists tools for standard development.
 
 The [Standard Development Template](https://airtable.com/appPKPGl0TPBAEjyW/) is a tool for managing and documenting the research and development of a data standard. It is structured according to the standard development methodology documented in this handbook.
 
-The template is designed to promote rigorous documentation of use cases, user stories, and requirements while ensuring that the data model is grounded through explicit links to the requirements met by each of its elements.
+The template is designed to promote rigorous documentation of use cases, user stories, and requirements, while ensuring that the data model is grounded through explicit links to the requirements met by each of its elements.
 
 To aid understanding, the template is populated with example records based on the [Open Fibre Data Standard](https://open-fibre-data-standard.readthedocs.io/en/latest/).

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,0 +1,13 @@
+# Tools
+
+This page lists tools for standard development.
+
+## Research and development
+
+### Standard Development Template (Airtable)
+
+The [Standard Development Template](https://airtable.com/appPKPGl0TPBAEjyW/) is a tool for managing and documenting the research and development of a data standard. It is structured according to the standard development methodology documented in this handbook.
+
+The template is designed to promote rigorous documentation of use cases, user stories, and requirements while ensuring that the data model is grounded through explicit links to the requirements met by each of its elements.
+
+To aid understanding, the template is populated with example records based on the [Open Fibre Data Standard](https://open-fibre-data-standard.readthedocs.io/en/latest/).

--- a/metaschema.json
+++ b/metaschema.json
@@ -1,0 +1,8 @@
+{
+    "properties": {
+        "deprecatedDetails": {
+            "$ref": "http://json-schema-extension.readthedocs.io/1__0__0/2020-12/metaschema.json#/properties/deprecatedDetails"
+        }
+    }
+    
+}

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,8 @@
 odsc-default-sphinx-theme
 myst-parser
+pygments-csv-lexer
 sphinx
+sphinx-design
 sphinx-intl
+sphinx-togglebutton
 sphinxcontrib-mermaid

--- a/requirements.in
+++ b/requirements.in
@@ -6,3 +6,4 @@ sphinx-design
 sphinx-intl
 sphinx-togglebutton
 sphinxcontrib-mermaid
+sphinxcontrib-opendataservices-jsonschema

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ docutils==0.21.2
     # via
     #   myst-parser
     #   sphinx
+    #   sphinx-togglebutton
 furo==2024.8.6
     # via odsc-default-sphinx-theme
 idna==3.10
@@ -51,7 +52,10 @@ packaging==24.2
 pygments==2.19.1
     # via
     #   furo
+    #   pygments-csv-lexer
     #   sphinx
+pygments-csv-lexer==0.1.3
+    # via -r requirements.in
 pyyaml==6.0.2
     # via
     #   myst-parser
@@ -68,11 +72,17 @@ sphinx==8.1.3
     #   furo
     #   myst-parser
     #   sphinx-basic-ng
+    #   sphinx-design
     #   sphinx-intl
+    #   sphinx-togglebutton
     #   sphinxcontrib-mermaid
 sphinx-basic-ng==1.0.0b2
     # via furo
+sphinx-design==0.6.1
+    # via -r requirements.in
 sphinx-intl==2.3.1
+    # via -r requirements.in
+sphinx-togglebutton==0.3.2
     # via -r requirements.in
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
@@ -92,6 +102,8 @@ typing-extensions==4.12.2
     # via beautifulsoup4
 urllib3==2.3.0
     # via requests
+wheel==0.45.1
+    # via sphinx-togglebutton
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@
 #
 alabaster==1.0.0
     # via sphinx
+attrs==25.3.0
+    # via referencing
 babel==2.17.0
     # via
     #   sphinx
@@ -23,6 +25,7 @@ docutils==0.21.2
     #   myst-parser
     #   sphinx
     #   sphinx-togglebutton
+    #   sphinxcontrib-opendataservices-jsonschema
 furo==2024.8.6
     # via odsc-default-sphinx-theme
 idna==3.10
@@ -33,6 +36,16 @@ jinja2==3.1.5
     # via
     #   myst-parser
     #   sphinx
+jscc==0.3.0
+    # via sphinxcontrib-opendataservices-jsonschema
+json-merge-patch==0.2
+    # via jscc
+jsonpointer==3.0.0
+    # via sphinxcontrib-opendataservices-jsonschema
+jsonref==1.1.0
+    # via
+    #   jscc
+    #   sphinxcontrib-opendataservices-jsonschema
 markdown-it-py==3.0.0
     # via
     #   mdit-py-plugins
@@ -44,7 +57,9 @@ mdit-py-plugins==0.4.2
 mdurl==0.1.2
     # via markdown-it-py
 myst-parser==4.0.0
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   sphinxcontrib-opendataservices-jsonschema
 odsc-default-sphinx-theme==0.0.1
     # via -r requirements.in
 packaging==24.2
@@ -60,8 +75,14 @@ pyyaml==6.0.2
     # via
     #   myst-parser
     #   sphinxcontrib-mermaid
+referencing==0.36.2
+    # via sphinxcontrib-opendataservices-jsonschema
 requests==2.32.3
-    # via sphinx
+    # via
+    #   jscc
+    #   sphinx
+rpds-py==0.23.1
+    # via referencing
 snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.6
@@ -93,6 +114,8 @@ sphinxcontrib-htmlhelp==2.1.0
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
 sphinxcontrib-mermaid==1.0.0
+    # via -r requirements.in
+sphinxcontrib-opendataservices-jsonschema==0.7.1
     # via -r requirements.in
 sphinxcontrib-qthelp==2.0.0
     # via sphinx


### PR DESCRIPTION
This PR updates the old schema development page and related content to reflect the process followed and lessons learned from more recent standard development work.

[Preview](https://os4d--49.org.readthedocs.build/)

* Closes https://github.com/OpenDataServices/os4d/issues/39
* Closes https://github.com/OpenDataServices/os4d/issues/38
* Closes https://github.com/OpenDataServices/os4d/issues/36
* Closes https://github.com/OpenDataServices/os4d/issues/23

The new and updated content links to the following new repositories and tools, which should be reviewed at the same time:

* [JSON Schema Extension](https://json-schema-extension.readthedocs.io/)
* [Codelist Schema](https://codelist-schema.readthedocs.io/)
* [Standard Development Template (Airtable)](https://airtable.com/appPKPGl0TPBAEjyW/shrTREzZjthYCdj1g)