### PR TITLE
docs: Update title

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -146,7 +146,7 @@ html_theme = "odsc_default_sphinx_theme"
 # The name for this set of Sphinx documents.
 # "<project> v<release> documentation" by default.
 #
-# html_title = 'Open Data Services Sphinx Base'
+html_title = 'Standards Lab Handbook'
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Standards Lab: an open data standard toolkit
+# Standards Lab Handbook
 
 This handbook provides an overview of the creation, maintenance and adoption of a policy-related open data standard.
 


### PR DESCRIPTION
This PR fixes two minor annoyances:

1. The sidebar title was very long, repetitive and included a meaningless version number

2. The title on `index.md` was "Standards Lab: an open data standard toolkit", but everywhere else it is described as a handbook, not a toolkit.

![image](https://github.com/user-attachments/assets/279bf694-9d93-40ef-9460-fa2f5b347c22)

Now the sidebar title and title on index.md are both 'Standards Lab Handbook':

![image](https://github.com/user-attachments/assets/57ec3a3f-386c-4089-a9a4-08c41f223fbb)

